### PR TITLE
1984'd a lot of LRP out of the game

### DIFF
--- a/Content.Shared/CardboardBox/Components/CardboardBoxComponent.cs
+++ b/Content.Shared/CardboardBox/Components/CardboardBoxComponent.cs
@@ -36,7 +36,7 @@ public sealed partial class CardboardBoxComponent : Component
 	/// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
 	[DataField("quiet")]
-	public bool Quiet = false;
+	public bool Quiet = true; // horizon - no fun allowed
 
     /// <summary>
     /// How far should the box opening effect go?

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -141,8 +141,8 @@
       amount: 2
     - id: DrinkLemonLimeCan
       amount: 2
-    - id: DrinkFourteenLokoCan
-      amount: 2
+ #   - id: DrinkFourteenLokoCan
+ #     amount: 2
 
 - type: entity
   id: CrateFoodSoftdrinksLarge

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
@@ -6,7 +6,7 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
-    DrinkFourteenLokoCan: 2
+ #   DrinkFourteenLokoCan: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
@@ -6,7 +6,7 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
-    DrinkFourteenLokoCan: 2
+ #   DrinkFourteenLokoCan: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
@@ -7,7 +7,7 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
-    DrinkFourteenLokoCan: 2
+ #   DrinkFourteenLokoCan: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
@@ -6,7 +6,7 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
-    DrinkFourteenLokoCan: 2
+#    DrinkFourteenLokoCan: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
@@ -6,7 +6,7 @@
     DrinkRootBeerCan: 3
     DrinkIcedTeaCan: 3
     DrinkLemonLimeCan: 3
-    DrinkFourteenLokoCan: 3
+ #   DrinkFourteenLokoCan: 3
   emaggedInventory:
     DrinkNukieCan: 3
     DrinkChangelingStingCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
@@ -7,7 +7,7 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
-    DrinkFourteenLokoCan: 2
+ #   DrinkFourteenLokoCan: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
@@ -6,7 +6,7 @@
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkLemonLimeCan: 2
-    DrinkFourteenLokoCan: 2
+#    DrinkFourteenLokoCan: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Datasets/tips.yml
+++ b/Resources/Prototypes/Datasets/tips.yml
@@ -10,7 +10,7 @@
   - "Some plants, such as galaxy thistle, can be ground up into extremely useful and potent medicines."
   - "Mopping up puddles and draining them into other containers conserves the reagents found in the puddle."
   - "Floor drains, usually found in the chef's freezer or janitor's office, rapidly consume reagent found in puddles around them--including blood."
-  - "Cognizine, a hard to manufacture chemical, makes animals sentient when they are injected with it."
+  - "Cognizine, an impossible to manufacture chemical, makes animals sentient when they are injected with it."
   - "Loaded mousetraps are incredibly effective at dealing with all manner of low-mass mobs--including Rat Servants."
   - "Fire extinguishers can be loaded with any reagent in the game."
   - "Some reagents, like chlorine trifluoride, have unique effects when applied by touch, such as through a spray bottle or foam."

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
@@ -126,7 +126,7 @@
     - SpaceGlue
     - SpaceCleaner
     - MilkSpoiled
-    - FourteenLoko
+#    - FourteenLoko
 
 - type: entity
   parent: DrinkBottleGlassBaseFull

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1318,10 +1318,10 @@
       layers:
         - state: icon
           shader: unshaded
-    - type: WeaponRandom
-      damageBonus:
-          types:
-              Blunt: 1000
+#    - type: WeaponRandom # no randomly gibbing people on HRP - horizon
+#      damageBonus:
+#          types:
+#              Blunt: 1000
     - type: StaminaDamageOnHit
       damage: 8
     - type: Item

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -48,7 +48,7 @@
     sound:
       path: /Audio/Effects/teleport_arrival.ogg
   - type: Psionic #Nyano - Summary: makes psionic on creation.
-  - type: GlimmerSource #Nyano - Summary: makes this a potential source of Glimmer. 
+  - type: GlimmerSource #Nyano - Summary: makes this a potential source of Glimmer.
     active: false
 
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -50,12 +50,12 @@
     critThreshold: 85
   - type: TypingIndicator
     proto: felinid
-  - type: PseudoItem
-    storedOffset: 0,17
-    shape:
-      - 0,0,1,4
-      - 0,2,3,4
-      - 4,0,5,4
+#  - type: PseudoItem # horizon - disable felinid dufflebag
+#    storedOffset: 0,17
+#    shape:
+#      - 0,0,1,4
+#      - 0,2,3,4
+#      - 4,0,5,4
   - type: Vocal
     wilhelm: "/Audio/Nyanotrasen/Voice/Felinid/cat_wilhelm.ogg"
     sounds:

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -26,7 +26,7 @@
           cost: 2
         - proto: CloningPodMachineCircuitboard
           cost: 2
-        - proto: CognizineChemistryBottle
+#        - proto: CognizineChemistryBottle
         - proto: FoodBoxDonkpocketCarp
           prob: 0.5
         - proto: CrateSalvageEquipment

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -67,7 +67,7 @@
     # rare armor
     ClothingOuterArmorARC: 1.0 # DeltaV - ClothingOuterArmorRiot replaced in favour of ARC suit
     # rare chemicals
-    CognizineChemistryBottle: 1.0
+#    CognizineChemistryBottle: 1.0
     OmnizineChemistryBottle: 1.0
     # money
     SpaceCash2500: 1.0

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -273,17 +273,17 @@
     Carbon: 2
     Oxygen: 1
 
-- type: reaction
-  id: FourteenLoko
-  reactants:
-    Coffee:
-      amount: 1
-    JuiceLime:
-      amount: 1
-    Vodka:
-      amount: 1
-  products:
-    FourteenLoko: 3
+#- type: reaction # horizon - disabling the recipe & buying it, don't want it accessible
+#  id: FourteenLoko
+#  reactants:
+#    Coffee:
+#      amount: 1
+#    JuiceLime:
+#      amount: 1
+#    Vodka:
+#      amount: 1
+#  products:
+#    FourteenLoko: 3
 
 - type: reaction
   id: GargleBlaster

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -356,17 +356,17 @@
   products:
     Siderlac: 2
 
-- type: reaction
-  id: Cognizine
-  reactants:
-    CarpoToxin:
-      amount: 1
-    Siderlac:
-      amount: 1
-    Acetone:
-      amount: 1
-  products:
-    Cognizine: 1
+#- type: reaction # all cognizine recipes and most spawns removed - horizon
+#  id: Cognizine
+#  reactants:
+#    CarpoToxin:
+#      amount: 1
+#    Siderlac:
+#      amount: 1
+#    Acetone:
+#      amount: 1
+#  products:
+#    Cognizine: 1
 
 - type: reaction
   id: Sigynate


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Felinids can no longer enter duffelbags, 14 loko is gone from natural spawns (may be mapped in, this is not covered in this pass), cognizine is no longer accessible from anything other than anomalies and random plant mutations, rubber hammer no longer gibs people, and boxes no longer make MGS reference chimes.

Closes #44, #8, #35, #7, #3.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
MGS reference chimes were constant and annoying on MRP servers, cognizine was spammed as soon as it was manufactured, felinids in duffel bags caused all sorts of balance issues, and 14 loko was just poison. And no comment necessary on the rubber hammer.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This was handled mostly by yml changes, with one default variable change for the MGS reference chime -- you can actually re-enable the reference from variable viewer.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
(hard to show the ABSENCE of features, but I did confirm them in a local server)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- remove: Removed metal gear solid reference from cardboard boxes.
- tweak: Cognizine is now anomalies, artifacts and plant-mutation only.
- remove: Felinids can no longer fit in duffel bags.
- remove: 14 loko is gone from all vending machines, and no recipe exists anymore.
- remove: Rubber hammer no longer gibs people at random.
